### PR TITLE
Fix mobile and associated state mgmt clean-up

### DIFF
--- a/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.html
+++ b/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.html
@@ -4,11 +4,7 @@
 </div>
 
 <button id="talkback-btn" mat-fab color="primary" (click)="onStartStop()">
-  @if (!isListening()) {
-    <mat-icon>mic_off</mat-icon>
-  } @else {
-    <mat-icon>mic</mat-icon>
-  }
+  <mat-icon>{{ isListening() ? 'mic' : 'mic_off' }}</mat-icon>
 </button>
 
 <button

--- a/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.html
+++ b/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.html
@@ -1,10 +1,10 @@
-<div class="status">{{ status }}</div>
+<div class="status">{{ getStatusMessage() }}</div>
 <div class="dialog">
   <div *ngFor="let line of dialog">{{ line }}</div>
 </div>
 
 <button id="talkback-btn" mat-fab color="primary" (click)="onStartStop()">
-  @if (!recognizing) {
+  @if (!isListening()) {
     <mat-icon>mic_off</mat-icon>
   } @else {
     <mat-icon>mic</mat-icon>

--- a/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
+++ b/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
@@ -5,7 +5,7 @@ import {NgZone, Output, EventEmitter} from '@angular/core';
 import {environment} from 'environments/environment';
 
 enum ListenState {
-  New,
+  Stopped,
   Listening,
   Processing,
   Speaking,
@@ -28,7 +28,7 @@ export class SpeechRecognizerComponent {
 
   dialog: string[] = [];
 
-  listenState: ListenState = ListenState.New;
+  listenState: ListenState = ListenState.Stopped;
 
   @Output() newDialogLineEvent = new EventEmitter<string[]>();
   @Output() transcriptDowloadEvent = new EventEmitter<string[]>();
@@ -122,7 +122,7 @@ export class SpeechRecognizerComponent {
 
   getStatusMessage() {
     switch (this.listenState) {
-      case ListenState.New:
+      case ListenState.Stopped:
         return 'Click the microphone icon to start the conversation...';
       case ListenState.Listening:
         return 'Listening...';


### PR DESCRIPTION
Mobile fix required checking that the confidence was > 0 in the speed recognition event results.

But mobile listening also times out really quickly, so I cleaned up the state mgmt in order to restart
listening if it times out.