### PR TITLE
scrolling

### DIFF
--- a/conversational-client/src/app/app.component.html
+++ b/conversational-client/src/app/app.component.html
@@ -3,7 +3,7 @@
     ><app-mode-selector></app-mode-selector
   ></mat-sidenav>
 
-  <mat-sidenav-content id="content">
+  <mat-sidenav-content id="content" #content>
     <mat-toolbar color="primary">
       <mat-icon (click)="sidenav.toggle()">menu</mat-icon>&nbsp;
       <span>Conversational Client</span>

--- a/conversational-client/src/app/app.component.scss
+++ b/conversational-client/src/app/app.component.scss
@@ -7,12 +7,16 @@
   justify-content: space-between;
 }
 
+mat-toolbar {
+  min-height: 64px;
+}
+
 button {
   margin: 12px;
 }
 
 .conversation {
-  padding: 0px 12px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
 }
@@ -46,6 +50,6 @@ mat-chip-set {
 .toolbar {
   display: flex;
   padding: 12px;
-  margin-top: 24px;
+  margin-top: 12px;
   align-items: center;
 }

--- a/conversational-client/src/app/app.component.ts
+++ b/conversational-client/src/app/app.component.ts
@@ -1,8 +1,9 @@
-import {Component, ViewChild} from '@angular/core';
+import {Component, ElementRef, ViewChild} from '@angular/core';
 import {SpeechRecognizerComponent} from '@components/speech-recognizer/speech-recognizer.component';
 import {ModeSelectorComponent} from '@components/mode-selector/mode-selector.component';
 import {ChatService} from '@services/chat.service';
 import {ChatMessage} from 'app/data/conversation';
+import {debounce} from './util/debounce';
 
 @Component({
   selector: 'app-root',
@@ -14,11 +15,16 @@ export class AppComponent {
   speechRecognizerComponent!: SpeechRecognizerComponent;
   @ViewChild(ModeSelectorComponent)
   modeSelectorComponent!: ModeSelectorComponent;
+  @ViewChild('content', {read: ElementRef}) contentElement!: ElementRef;
 
   conversation: ChatMessage[] = [];
   interimDialogLine: string = '';
 
-  constructor(private chatService: ChatService) {}
+  private debouncedScrollToBottom: () => void;
+
+  constructor(private chatService: ChatService) {
+    this.debouncedScrollToBottom = debounce(this.scrollToBottom);
+  }
 
   handleNewLineOfDialog(dialog: string) {
     if (!dialog) {
@@ -30,7 +36,6 @@ export class AppComponent {
       this.conversation,
       this.modeSelectorComponent.currentMode
     );
-
     responseObservable.subscribe((llmResponse: string) => {
       // Update the UI only once, when we receive the LLM response.
       this.interimDialogLine = '';
@@ -38,6 +43,7 @@ export class AppComponent {
       const llmMessage = {content: llmResponse, author: 'llm'};
       this.conversation = [...this.conversation, userMessage, llmMessage];
       this.speechRecognizerComponent.handleLLMResponse(llmResponse);
+      this.debouncedScrollToBottom();
     });
   }
 
@@ -47,5 +53,13 @@ export class AppComponent {
 
   donwloadTranscript() {
     this.chatService.downloadTranscript(this.conversation);
+  }
+
+  private scrollToBottom() {
+    this.contentElement.nativeElement.scroll({
+      top: this.contentElement.nativeElement.scrollHeight,
+      left: 0,
+      behavior: 'smooth',
+    });
   }
 }

--- a/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
+++ b/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
@@ -102,9 +102,6 @@ export class SpeechRecognizerComponent {
       this.dialogLine = interimTranscript;
       this.newInterimDialogLineEvent.emit(this.dialogLine);
     }
-
-    // Scroll to the bottom of the page
-    window.scrollTo(0, document.body.scrollHeight);
   }
 
   isListening() {

--- a/conversational-client/src/app/services/chat.service.spec.ts
+++ b/conversational-client/src/app/services/chat.service.spec.ts
@@ -1,13 +1,13 @@
 import {TestBed} from '@angular/core/testing';
 
-import {APIService} from './chat.service';
+import {ChatService} from './chat.service';
 
-describe('APIService', () => {
-  let service: APIService;
+describe('ChatService', () => {
+  let service: ChatService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(APIService);
+    service = TestBed.inject(ChatService);
   });
 
   it('should be created', () => {

--- a/conversational-client/src/app/util/debounce.ts
+++ b/conversational-client/src/app/util/debounce.ts
@@ -1,0 +1,12 @@
+// Delays the execution of a `func` by `waitMs` milliseconds, clearing
+// any previous unexecuted calls.
+export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
+  func: F,
+  waitMs = 300
+): F {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (this: ThisParameterType<F>, ...args: Parameters<F>) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func.apply(this, args), waitMs);
+  } as F;
+}


### PR DESCRIPTION
- scrolls to the bottom of the page when receiving a message
  - disables scrolling for interim messages to allow the user to read the conversation history while speaking
  - debounces the call so we only scroll once, when the conversation is updated
- minor style and code fixes