### PR TITLE
Add world_state and first version of history_tutor

### DIFF
--- a/conversational-client/src/app/app.component.html
+++ b/conversational-client/src/app/app.component.html
@@ -12,10 +12,10 @@
     </mat-toolbar>
 
     <!-- Custom UI for specific modes -->
-    <div *ngIf="currentMode === 'history_tutor'" class="additional-ui">
+    <div *ngIf="currentMode === 'history_tutor'" class="prompt-mode-container">
       <app-history-tutor></app-history-tutor>
     </div>
-    <div *ngIf="currentMode === 'fake'" class="additional-ui">
+    <div *ngIf="currentMode === 'fake'" class="prompt-mode-container">
       <app-fake-mode></app-fake-mode>
     </div>
     <!-- End custom UI -->

--- a/conversational-client/src/app/app.component.html
+++ b/conversational-client/src/app/app.component.html
@@ -1,6 +1,8 @@
 <mat-sidenav-container>
   <mat-sidenav opened #sidenav mode="side"
-    ><app-mode-selector></app-mode-selector
+    ><app-mode-selector
+      (modeChange)="handleModeChange($event)"
+    ></app-mode-selector
   ></mat-sidenav>
 
   <mat-sidenav-content id="content" #content>
@@ -9,7 +11,17 @@
       <span>Conversational Client</span>
     </mat-toolbar>
 
+    <!-- Custom UI for specific modes -->
+    <div *ngIf="currentMode === 'history_tutor'" class="additional-ui">
+      <app-history-tutor></app-history-tutor>
+    </div>
+    <div *ngIf="currentMode === 'fake'" class="additional-ui">
+      <app-fake-mode></app-fake-mode>
+    </div>
+    <!-- End custom UI -->
+
     <div>
+      <!-- Main conversation panel-->
       <div class="conversation">
         <div
           *ngFor="let msg of conversation"

--- a/conversational-client/src/app/app.component.scss
+++ b/conversational-client/src/app/app.component.scss
@@ -15,7 +15,7 @@ button {
   margin: 12px;
 }
 
-.additional-ui {
+.prompt-mode-container {
   vertical-align: top;
 }
 

--- a/conversational-client/src/app/app.component.scss
+++ b/conversational-client/src/app/app.component.scss
@@ -15,6 +15,10 @@ button {
   margin: 12px;
 }
 
+.additional-ui {
+  vertical-align: top;
+}
+
 .conversation {
   padding: 12px;
   display: flex;

--- a/conversational-client/src/app/app.component.ts
+++ b/conversational-client/src/app/app.component.ts
@@ -26,6 +26,8 @@ export class AppComponent {
 
   conversation: ChatMessage[] = [];
   interimDialogLine: string = '';
+
+  // TODO: Create an object definition for this.
   worldState: object = {};
 
   // TODO: Refactor so this is only set in one place.
@@ -41,9 +43,6 @@ export class AppComponent {
     this.currentMode = this.modeSelectorComponent.currentMode;
   }
 
-  // TODO: Is it possible to directly reference the modeSelectorComponent.currentMode
-  // instead?I tried this but I get an ExpressionChangedAfterItHasBeenCheckedError and the
-  // fix for that seemed even more messy. Sending an event feels like overkill though?
   handleModeChange(mode: PromptMode) {
     this.currentMode = mode;
   }
@@ -52,7 +51,7 @@ export class AppComponent {
     if (!dialog) {
       return;
     }
-    const responseObservable = this.chatService.sendMessageToServer(
+    const responseObservable = this.chatService.sendMessage(
       dialog,
       this.conversation,
       this.worldState,

--- a/conversational-client/src/app/app.module.ts
+++ b/conversational-client/src/app/app.module.ts
@@ -16,6 +16,8 @@ import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatIconModule} from '@angular/material/icon';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatList, MatListItem} from '@angular/material/list';
+import {HistoryTutorComponent} from '@components/history-tutor/history-tutor.component';
+import {FakeModeComponent} from '@components/fake-mode/fake-mode.component';
 
 const materialModules = [
   MatButtonModule,
@@ -32,6 +34,8 @@ const materialModules = [
     AppComponent,
     SpeechRecognizerComponent,
     ModeSelectorComponent,
+    HistoryTutorComponent,
+    FakeModeComponent,
   ],
   imports: [
     BrowserModule,

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.css
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.css
@@ -1,0 +1,4 @@
+.worldstate {
+    text-align: center;
+    white-space: pre;
+}

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.html
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.html
@@ -1,0 +1,5 @@
+<div style="text-align: center; white-space: pre">
+  <b>Fake Mode World State</b><br />
+  {{ worldStateDisplay }}
+  <b>----</b>
+</div>

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.html
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.html
@@ -1,4 +1,4 @@
-<div style="text-align: center; white-space: pre">
+<div class="worldstate">
   <b>Fake Mode World State</b><br />
   {{ worldStateDisplay }}
   <b>----</b>

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.spec.ts
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.spec.ts
@@ -1,0 +1,22 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {FakeModeComponent} from './fake-mode.component';
+
+describe('FakeModeComponent', () => {
+  let component: FakeModeComponent;
+  let fixture: ComponentFixture<FakeModeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FakeModeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FakeModeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.ts
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.ts
@@ -7,12 +7,10 @@ import {NgZone} from '@angular/core';
   styleUrl: './fake-mode.component.css',
 })
 export class FakeModeComponent {
-  worldState: object | undefined = undefined;
   worldStateDisplay: string = '';
   constructor(private zone: NgZone) {}
 
   updateWorldState(worldState: object): object {
-    this.worldState = worldState;
     this.worldStateDisplay = JSON.stringify(worldState);
     return worldState;
   }

--- a/conversational-client/src/app/components/fake-mode/fake-mode.component.ts
+++ b/conversational-client/src/app/components/fake-mode/fake-mode.component.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+import {NgZone} from '@angular/core';
+
+@Component({
+  selector: 'app-fake-mode',
+  templateUrl: './fake-mode.component.html',
+  styleUrl: './fake-mode.component.css',
+})
+export class FakeModeComponent {
+  worldState: object | undefined = undefined;
+  worldStateDisplay: string = '';
+  constructor(private zone: NgZone) {}
+
+  updateWorldState(worldState: object): object {
+    this.worldState = worldState;
+    this.worldStateDisplay = JSON.stringify(worldState);
+    return worldState;
+  }
+}

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.css
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.css
@@ -1,0 +1,4 @@
+.container {
+    padding-left: 4em;
+    white-space: pre;
+}

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.html
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.html
@@ -1,0 +1,5 @@
+<div style="padding-left: 4em; white-space: pre">
+  <b>History Tutor State:</b>
+  {{ worldStateDisplay }}
+  ----
+</div>

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.html
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.html
@@ -1,4 +1,4 @@
-<div style="padding-left: 4em; white-space: pre">
+<div class="container">
   <b>History Tutor State:</b>
   {{ worldStateDisplay }}
   ----

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.spec.ts
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.spec.ts
@@ -1,0 +1,22 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {HistoryTutorComponent} from './history-tutor.component';
+
+describe('HistoryTutorComponent', () => {
+  let component: HistoryTutorComponent;
+  let fixture: ComponentFixture<HistoryTutorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HistoryTutorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HistoryTutorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.ts
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-history-tutor',
+  templateUrl: './history-tutor.component.html',
+  styleUrl: './history-tutor.component.css',
+})
+export class HistoryTutorComponent {
+  worldState: object | undefined = undefined;
+  worldStateDisplay: string | undefined = undefined;
+
+  updateWorldState(worldState: object): object {
+    this.worldState = worldState;
+    this.worldStateDisplay = JSON.stringify(worldState);
+    return worldState;
+  }
+}

--- a/conversational-client/src/app/components/history-tutor/history-tutor.component.ts
+++ b/conversational-client/src/app/components/history-tutor/history-tutor.component.ts
@@ -6,12 +6,10 @@ import {Component} from '@angular/core';
   styleUrl: './history-tutor.component.css',
 })
 export class HistoryTutorComponent {
-  worldState: object | undefined = undefined;
   worldStateDisplay: string | undefined = undefined;
 
   updateWorldState(worldState: object): object {
-    this.worldState = worldState;
-    this.worldStateDisplay = JSON.stringify(worldState);
+    this.worldStateDisplay = JSON.stringify(worldState, null, 2);
     return worldState;
   }
 }

--- a/conversational-client/src/app/components/mode-selector/mode-selector.component.ts
+++ b/conversational-client/src/app/components/mode-selector/mode-selector.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, EventEmitter, Output} from '@angular/core';
 import {PromptMode} from 'app/data/conversation';
 
 @Component({
@@ -10,9 +10,10 @@ export class ModeSelectorComponent {
   modes: PromptMode[] = ['default', 'fake', 'history_tutor'];
   currentMode: PromptMode = 'default';
 
-  constructor() {}
+  @Output() modeChange = new EventEmitter<PromptMode>();
 
   onSelectMode(mode: PromptMode) {
     this.currentMode = mode;
+    this.modeChange.emit(mode);
   }
 }

--- a/conversational-client/src/app/services/chat.service.ts
+++ b/conversational-client/src/app/services/chat.service.ts
@@ -12,14 +12,16 @@ export class ChatService {
 
   constructor(private http: HttpClient) {}
 
-  getLLMLineOfDialog(
+  sendMessageToServer(
     request: string,
     messageHistory: ChatMessage[],
+    worldState: object,
     promptMode: PromptMode
   ): Observable<string> {
     const formData = new FormData();
     formData.append('q', request);
     formData.append('message_history', JSON.stringify(messageHistory));
+    formData.append('world_state', JSON.stringify(worldState));
     formData.append('mode', promptMode);
     return this.http.post(this.apiUrl, formData, {responseType: 'text'});
   }

--- a/conversational-client/src/app/services/chat.service.ts
+++ b/conversational-client/src/app/services/chat.service.ts
@@ -12,7 +12,7 @@ export class ChatService {
 
   constructor(private http: HttpClient) {}
 
-  sendMessageToServer(
+  sendMessage(
     request: string,
     messageHistory: ChatMessage[],
     worldState: object,

--- a/py-server/default_model.py
+++ b/py-server/default_model.py
@@ -31,7 +31,7 @@ class DefaultModel:
         end_time = time.time()
         print(f"Created DefaultModel in: {end_time - start_time:.2f} seconds")
 
-    def chat(self, message_history, message):
+    def chat(self, message_history, world_state, message):
         start_time = time.time()
         messages = self.convert_message_history(message_history)
         chat_session = self.chat_model.start_chat(
@@ -41,7 +41,7 @@ class DefaultModel:
         end_time = time.time()
         print(f"DefaultModel chat took: {end_time - start_time:.2f} seconds")
         text = res.candidates[0].text
-        return text
+        return text, None
 
     def convert_message_history(self, message_history):
         """

--- a/py-server/fake_model.py
+++ b/py-server/fake_model.py
@@ -1,3 +1,4 @@
+# TODO: Add a base class for a common interface for all models
 class FakeModel:
     def chat(self, message_history, world_state, message):
         print(f"Fake called with world state {world_state}")

--- a/py-server/fake_model.py
+++ b/py-server/fake_model.py
@@ -1,3 +1,9 @@
 class FakeModel:
-    def chat(self, message_history, message):
-        return "This is a canned response used for testing."
+    def chat(self, message_history, world_state, message):
+        print(f"Fake called with world state {world_state}")
+        if not world_state:
+            world_state = [{"user": message}]
+        else:
+            world_state.append({"user": message})
+
+        return "This is a canned response.", world_state

--- a/py-server/history_tutor/history_tutor.py
+++ b/py-server/history_tutor/history_tutor.py
@@ -102,6 +102,11 @@ Chat history: {chat_history}
 BLACK_DEATH_TUTOR_CONTEXT = "./history_tutor/the_black_death.md"
 
 
+def load_file(filename):
+    with open(filename, "r") as file:
+        return file.read()
+
+
 class HistoryTutor:
     def __init__(self):
         start = time.time()
@@ -112,9 +117,12 @@ class HistoryTutor:
         end = time.time()
         print(f"HistoryTutor loaded in {end - start:0.2f} seconds")
 
-        self.lesson_context = self.load_file(BLACK_DEATH_TUTOR_CONTEXT)
+        self.lesson_context = load_file(BLACK_DEATH_TUTOR_CONTEXT)
 
     def chat(self, message_history, world_state, message):
+        if not world_state:
+            print("No world state received, creating new one")
+            world_state = self.build_world_state()
 
         updated_world_state = self.update_world_state(world_state, message_history)
 
@@ -152,7 +160,3 @@ class HistoryTutor:
             return ["failed"]
 
         return output
-
-    def load_file(self, filename):
-        with open(filename, "r") as file:
-            return file.read()

--- a/py-server/history_tutor/history_tutor.py
+++ b/py-server/history_tutor/history_tutor.py
@@ -5,46 +5,154 @@ from langchain.chains import LLMChain
 from langchain_core.output_parsers import JsonOutputParser
 import json
 from langchain_core.messages import AIMessage, SystemMessage, HumanMessage
+from langchain_google_vertexai import VertexAI
 
 PROMPT = """
-    You are an expert AUDIO chatbot designed to support my project work.
+    You are an expert AUDIO chatbot designed to teach GCSE History.
     
-    Respond as if you are having a natural VOICE conversation.
+    This is the history lesson plan.:
+    ```
+    {lesson_context}
+    ```
     
-    NEVER respond with bullet-points.
+    The JSON below represents all the questions the student needs to answer and whether or not they have answered:
+    ```
+    {world_state}
+    ```
     
-    Keep responses short — one or two sentences MAXIMUM.
+    Start by introducing the topic and giving a short summary of the main areas you'll be asking
+    questions about.
     
-    DON'T repeat the question that was just asked.
+    Then pick the next unanswered question from the list and ask it.
     
-    DON'T try to answer if you don't have enough information. Prompt the user
-    for more relevant information.
+    If they have answer correctly and completely, immediately ask the next unanswered question.
     
-    Before you reply, attend, think and remember all the
+    If they don't know the answer to the question or give an incorrect answer, provide a hint.
+    
+    If they don't get it after two hints, give them the answer.
+    
+    If there are multiple answers to a question, stay on that topic until it has been answered completely.
+    
+    If they ask a question about the topic, answer it, even if it is not in the provided information.
+    
+    If they give an incomplete answer, prompt them for more details.   
+    
+    Always be warm and encouraging. Before you reply, attend, think and remember all the
     instructions set here. You are truthful and never lie. Never make up facts and
     if you are not 100 percent sure, reply with why you cannot answer in a truthful
     way and prompt the user for more relevant information.
+  
 """
 
+INITIAL_WORLD_STATE_PROMPT = """
+    You are a history tutor. Based on this lesson plan, identify the main areas you'll be asking
+    questions about and organize them into a list. Include an attribute has_answered which is always false.
+    
+    Some questions have multiple parts to the answer, list all answers.
+    
+    This is the lesson plan:
+    ```
+    {lesson_context}
+    ```
+    
+    Return results as an array of JSON objects.   
+    [
+        {{
+            "question": "What were the different theories about the cause of the Black Death?",
+            "answers": [
+            {{answer: "Religion: God sent the plague as a punishment for people's sins.", has_answered="false"}},
+            {{answer: "Miasma: 'bad air' or smells caused by decaying rubbish.", has_answered="false}},
+            {{answer: "Four Humours: most physicians believed that disease was caused by an imbalance in the Four Humours.", has_answered="false}},
+            {{answer: "Outsiders: strangers or witches had caused the disease.", has_answered="false"}}
+            ]
+        }}
+        ...
+    ] 
+"""
 
-def load_file(filename):
-    with open(filename, "r") as file:
-        return file.read()
+UPDATE_WORLD_STATE_PROMPT = """
+You are a history tutor testing a student. The JSON below represents all the
+questions they need to answer and whether or not that have answered.
+
+```
+{world_state}
+```
+
+Based on the previous chat history with the student, update the world state to reflect
+any questions they have answered.
+
+Chat history: {chat_history}
+
+    Return results as an array of JSON objects.   
+    For Example:
+    [
+        {{
+            "question": "What were the different theories about the cause of the Black Death?",
+            "answers": [
+            {{answer: "Religion: God sent the plague as a punishment for people's sins.", has_answered="false"}},
+            {{answer: "Miasma: 'bad air' or smells caused by decaying rubbish.", has_answered="false}},
+            {{answer: "Four Humours: most physicians believed that disease was caused by an imbalance in the Four Humours.", has_answered="false}},
+            {{answer: "Outsiders: strangers or witches had caused the disease.", has_answered="false"}}
+            ]
+        }}
+        ...
+    ] 
+"""
+
+BLACK_DEATH_TUTOR_CONTEXT = "./history_tutor/the_black_death.md"
 
 
 class HistoryTutor:
     def __init__(self):
         start = time.time()
+        self.gemini = VertexAI(model_name="gemini-pro")
         self.chat_model = ChatVertexAI(
             model="gemini-pro", convert_system_message_to_human=True
         )
         end = time.time()
         print(f"HistoryTutor loaded in {end - start:0.2f} seconds")
 
-    def chat(self, message_history, message):
-        print(message_history, message)
-        messages = [SystemMessage(PROMPT)]
+        self.lesson_context = self.load_file(BLACK_DEATH_TUTOR_CONTEXT)
+
+    def chat(self, message_history, world_state, message):
+
+        updated_world_state = self.update_world_state(world_state, message_history)
+
+        system_prompt = PromptTemplate.from_template(PROMPT).format(
+            lesson_context=self.lesson_context,
+            world_state=json.dumps(updated_world_state),
+        )
+        messages = [SystemMessage(system_prompt)]
         messages.extend(message_history)
         messages.append(HumanMessage(message))
         response = self.chat_model.invoke(messages)
-        return response.content
+        return response.content, updated_world_state
+
+    def build_world_state(self):
+        world_state = {}
+        prompt = PromptTemplate.from_template(INITIAL_WORLD_STATE_PROMPT).format(
+            lesson_context=self.lesson_context
+        )
+        response = self.gemini.invoke(prompt)
+        parser = JsonOutputParser()
+        json = parser.parse(response)
+        return json
+
+    def update_world_state(self, world_state, chat_history):
+        prompt = PromptTemplate.from_template(UPDATE_WORLD_STATE_PROMPT).format(
+            world_state=json.dumps(world_state), chat_history=chat_history
+        )
+
+        try:
+            response = self.gemini.invoke(prompt)
+            parser = JsonOutputParser()
+            output = parser.parse(response)
+        except Exception as e:
+            print("Couldn't parse world_state", e)
+            return ["failed"]
+
+        return output
+
+    def load_file(self, filename):
+        with open(filename, "r") as file:
+            return file.read()

--- a/py-server/history_tutor/history_tutor_test.py
+++ b/py-server/history_tutor/history_tutor_test.py
@@ -1,14 +1,66 @@
 import unittest
 from history_tutor import HistoryTutor
-from main import build_message_history
+from langchain_core.messages import AIMessage, HumanMessage
+from tabulate import tabulate
+import json
 
 
 class TestHistoryTutor(unittest.TestCase):
     def setUp(self):
+        print("\n\n------")
+        self.message_history = []
         self.tutor = HistoryTutor()
+        self.world_state = self.tutor.build_world_state()
 
-    def test_conversation_no_history(self):
-        resp = self.tutor.chat(None, """Tell me a joke""")
+    def test_start_lesson(self):
+        self.send_message("start lesson")
+        self.send_message("was it god?")
+        self.send_message("what about miasma and bad smells")
+        self.send_message("prayer")
+        json_str = json.dumps(self.world_state, indent=4)
+        print(json_str)
+
+    @unittest.skip("skipping")
+    def test_create_initial_world_state(self):
+        state = self.tutor.build_world_state()
+        json_str = json.dumps(state, indent=4)
+        print(json_str)
+
+    @unittest.skip("skipping")
+    def test_update_world_state(self):
+        state = self.tutor.build_world_state()
+        latest_response = """
+          AI: What did people believe caused the Black Death?
+          User: Religion: God sent the plague as a punishment for people's sins.
+          AI: What other examples can you think of?
+          User: Miasma?
+        """
+        updated_state = self.tutor.update_world_state(state, latest_response)
+
+        json_str = json.dumps(updated_state, indent=4)
+        print(json_str)
+
+    def send_message(self, message):
+        response, updated_world_state = self.tutor.chat(
+            self.message_history, self.world_state, message
+        )
+        self.world_state = updated_world_state
+
+        # Updates our message history.
+        self.message_history.append(HumanMessage(message))
+        self.message_history.append(AIMessage(response))
+
+        print(
+            tabulate(
+                [
+                    [f"User:", f" {message}"],
+                    [f"AI:", f"{response}"],
+                ],
+                tablefmt="grid",
+            )
+        )
+
+        return response, updated_world_state
 
 
 if __name__ == "__main__":

--- a/py-server/history_tutor/the_black_death.md
+++ b/py-server/history_tutor/the_black_death.md
@@ -1,0 +1,53 @@
+# The Black Death, 1348-9
+
+The Black Death reached Britain in 1348, killing about one-third of the population. Ideas about what caused the Black Death and how it could be treated tell us a lot about how people in Late Medieval England thought about illness and disease.
+
+## Believed causes
+
+* Religion: God sent the plague as a punishment for people's sins.
+
+* Miasma: 'bad air' or smells caused by decaying rubbish. Four Humours: most physicians believed that disease was caused by an imbalance in the Four Humours. Outsiders: strangers or witches had caused the disease.
+
+# Prevention
+
+* Religious methods, such as prayer, donating to the Church and flagellation. People would punish themselves to avoid punishment from God.
+
+* Clearing up rubbish in the streets.
+
+* Smelling their toilets or other bad smells.
+
+* Lighting a fire in the room, ringing bells or having birds flying around the room to keep air moving. Carrying herbs and spices to avoid breathing in 'bad air'.
+
+* Not letting unknown people enter the town or village.
+
+# Example Question
+* If someone carried herbs and spices during the Black Death, what might they think was the source of the disease?
+
+# Example Answer
+* People carried herbs and spices to avoid breathing in 'bad air'. This would be because they thought the disease was spread by miasma.
+
+## Symptoms
+
+* swelling of the lymph glands into large lumps filled with pus (known as buboes)
+
+* fever and chills
+
+* headache
+
+* vomiting, diarrhoea and abdominal pain.
+
+## Treatments
+
+* praying and holding lucky charms
+
+* cutting open buboes to drain the pus 
+
+* holding bread against the buboes, then burying it in the ground
+
+* eating cool things and taking cold baths.
+
+## Key facts
+
+* Most people thought the Black Death was sent by God. Physicians and some others believed it was caused by an imbalance in the humours, or by miasma. 
+
+* People used a mix of rational and supernatural methods to try to prevent or treat the Black Death.

--- a/py-server/main_test.py
+++ b/py-server/main_test.py
@@ -2,10 +2,53 @@ import json
 import unittest
 from main import build_message_history
 from langchain_core.messages import HumanMessage, AIMessage
+from main import app
 
 
 # Create a test class for the build_message_history function
 class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self.ctx = app.app_context()
+        self.ctx.push()
+        self.client = app.test_client()
+
+    def tearDown(self):
+        self.ctx.pop()
+
+    def test_no_world_state(self):
+        req = {
+            "q": "user message",
+            "mode": "fake",
+        }
+        resp = self.client.post("/chat", data=req)
+        data = json.loads(resp.get_data())
+        self.assertEqual(data["response"], "This is a canned response.")
+        self.assertEqual(data["world_state"][0]["user"], "user message")
+
+    def test_world_state_round_trip(self):
+        req = {
+            "q": "user message 1",
+            "mode": "fake",
+            "worldstate": "[]",
+        }
+        resp = self.client.post("/chat", data=req)
+        data = json.loads(resp.get_data())
+        world_state = data["world_state"]
+
+        next_req = {
+            "q": "user message 2",
+            "mode": "fake",
+            "world_state": json.dumps(world_state),
+        }
+
+        resp2 = self.client.post("/chat", data=next_req)
+        data2 = json.loads(resp2.get_data())
+        world_state2 = data2["world_state"]
+        self.assertEqual(world_state2[0]["user"], "user message 1")
+        self.assertEqual(world_state2[1]["user"], "user message 2")
+
+    @unittest.skip("Not implemented")
     def test_build_message_history(self):
         incoming_messages = json.dumps(
             [
@@ -25,7 +68,6 @@ class TestMain(unittest.TestCase):
         output = build_message_history(incoming_messages)
         self.assertEqual(output, expected_messages)
 
-
     def test_invalid_history(self):
         incoming_messages = "xxx"
         try:
@@ -33,6 +75,7 @@ class TestMain(unittest.TestCase):
             self.fail("Should have thrown an exception")
         except Exception as e:
             pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a world_state json object which is passed between client and server and a ui element that's specific to each mode. 

In the history_tutor example, a second prompt updates the world-state based on the chat history to indicate if the user has answered the questions correctly which prompts the conversation prompt to move onto other questions.

The history_tutor component currently displays the full worldstate but as a next step will display a count of questions that still need to be answered.