### PR TITLE
use consistent server/client terminology

### DIFF
--- a/conversational-client/src/app/app.component.html
+++ b/conversational-client/src/app/app.component.html
@@ -29,9 +29,9 @@
         <div
           *ngFor="let msg of conversation"
           class="message-container"
-          [class.message-user]="msg.author === 'user'"
+          [class.message-user]="msg.author === 'human'"
         >
-          <mat-chip-set *ngIf="msg.author === 'llm'">
+          <mat-chip-set *ngIf="msg.author === 'ai'">
             <mat-chip>{{ msg.author }}</mat-chip>
           </mat-chip-set>
           <span class="message-content">{{ msg.content }}</span>

--- a/conversational-client/src/app/app.component.ts
+++ b/conversational-client/src/app/app.component.ts
@@ -64,17 +64,17 @@ export class AppComponent implements OnInit {
       this.agentState.worldState as object,
       this.agentId
     );
-    responseObservable.subscribe((llmResponse: string) => {
+    responseObservable.subscribe((agentResponse: string) => {
       // Update the UI only once, when we receive the LLM response.
       this.interimDialogLine = '';
 
-      const parsedResponse = JSON.parse(llmResponse);
-      const llmDialog = parsedResponse['response'];
+      const parsedResponse = JSON.parse(agentResponse);
+      const agentDialog = parsedResponse['response'];
       const worldState = parsedResponse['world_state'];
-      const userMessage = {content: dialog, author: 'user'};
-      const llmMessage = {content: llmDialog, author: 'llm'};
-      this.conversation = [...this.conversation, userMessage, llmMessage];
-      this.speechRecognizerComponent.handleLLMResponse(llmDialog);
+      const userMessage = {content: dialog, author: 'human' as const};
+      const agentMessage = {content: agentDialog, author: 'ai' as const};
+      this.conversation = [...this.conversation, userMessage, agentMessage];
+      this.speechRecognizerComponent.handleAgentResponse(agentDialog);
 
       const agentState = {messageHistory: this.conversation, worldState};
       const agent = this.agentComponentOutlet['_componentRef'].instance;
@@ -82,7 +82,9 @@ export class AppComponent implements OnInit {
         this.agentState = agent.processExchange(agentState);
       }
 
-      this.debouncedScrollToBottom();
+      if (this.currentAgentConfig.preferences.shouldDisplayChat) {
+        this.debouncedScrollToBottom();
+      }
     });
   }
 

--- a/conversational-client/src/app/components/agent-selector/agent-selector.component.ts
+++ b/conversational-client/src/app/components/agent-selector/agent-selector.component.ts
@@ -8,14 +8,14 @@ import {AgentsService} from '@services/agents.service';
   styleUrl: './agent-selector.component.css',
 })
 export class AgentSelectorComponent {
-  readonly _agentConfigs = inject(AgentsService).getAgentConfigs();
+  private readonly agentConfigs = inject(AgentsService).getAgentConfigs();
 
   @Input() selectedAgentId: AgentId | null = null;
 
   @Output() selectedAgentIdChange = new EventEmitter<AgentId>();
 
   get _agentIds() {
-    return [...this._agentConfigs.keys()];
+    return [...this.agentConfigs.keys()];
   }
 
   agentSelectionChanged(agentId: AgentId) {
@@ -24,7 +24,7 @@ export class AgentSelectorComponent {
   }
 
   getAgentDisplayName(agentId: AgentId) {
-    const config = this._agentConfigs.get(agentId)!;
+    const config = this.agentConfigs.get(agentId)!;
     return config.preferences.displayName;
   }
 }

--- a/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
+++ b/conversational-client/src/app/components/speech-recognizer/speech-recognizer.component.ts
@@ -121,7 +121,7 @@ export class SpeechRecognizerComponent {
     }
   }
 
-  handleLLMResponse(response: string) {
+  handleAgentResponse(response: string) {
     this.dialogLine = '';
 
     this.audio.src = this.apiUrl + response;

--- a/conversational-client/src/app/data/agent.ts
+++ b/conversational-client/src/app/data/agent.ts
@@ -16,6 +16,6 @@ export interface AgentState {
 
 // Represents a message in a conversation.
 export interface ChatMessage {
-  author: string;
+  author: 'human' | 'ai';
   content: string;
 }

--- a/py-server/main.py
+++ b/py-server/main.py
@@ -105,7 +105,7 @@ def build_message_history(message_history_json):
         objects, or None if empty list.
 
     Raises:
-        ValueError: If the message author is neither "user" nor "llm" or the
+        ValueError: If the message author is neither "ai" nor "human" or the
         message history can't be parsed.
     """
     messages = []
@@ -113,9 +113,9 @@ def build_message_history(message_history_json):
         return messages
     try:
         for message in json.loads(message_history_json):
-            if message["author"] == "user":
+            if message["author"] == "human":
                 messages.append(HumanMessage(message["content"]))
-            elif message["author"] == "llm":
+            elif message["author"] == "ai":
                 messages.append(AIMessage(message["content"]))
             else:
                 raise ValueError(f"Unknown message type: {message}")


### PR DESCRIPTION
- use LangChain terminolgoy in `ChatMessage.author`
- removes references to LLM in favor of Agent
- scroll to bottom only when agent component displays chat
- minor fixes in agent selector component