### PR TITLE
relative imports

### DIFF
--- a/server/agents/default_agent.py
+++ b/server/agents/default_agent.py
@@ -1,7 +1,7 @@
 import time
+from .agents import AgentResponse, ConversationalAgent
 from langchain_google_vertexai import ChatVertexAI
 from langchain_core.messages import SystemMessage
-from .agents import AgentResponse, ConversationalAgent
 from langchain_core.prompts import PromptTemplate
 
 SYSTEM_PROMPT = """

--- a/server/agents/default_agent_test.py
+++ b/server/agents/default_agent_test.py
@@ -1,10 +1,10 @@
 import time
 import unittest
 
+from .agents import AgentState
+from .default_agent import DefaultAgent
+from ..utils.test_utils import evaluate, send_chat
 from langchain_google_vertexai import VertexAI
-from agents.default_agent import DefaultAgent
-from utils.test_utils import evaluate, send_chat
-from .agents import AgentState, AgentResponse
 from langsmith import test, traceable
 
 

--- a/server/agents/fake_agent_test.py
+++ b/server/agents/fake_agent_test.py
@@ -1,18 +1,18 @@
 import unittest
+from .agents import AgentState
 from .fake_agent import FakeAgent
-import utils.test_utils
-from .agents import AgentResponse, AgentState
+from ..utils.test_utils import build_message_history_for_test
 
 
 class TestFakeAgent(unittest.TestCase):
     def test_chat(self):
         agent = FakeAgent()
-        message_history = utils.test_utils.build_message_history_for_test([])
+        message_history = build_message_history_for_test([])
         response, world_state = agent.chat(AgentState("Hello", message_history, None))
         self.assertEqual(response, "Fake response to message 0: Hello")
         self.assertEqual(world_state, {"last_message": "Hello", "message_count": 0})
 
-        message_history = utils.test_utils.build_message_history_for_test(
+        message_history = build_message_history_for_test(
             ["Hello", response, "How are you?"]
         )
         response, world_state = agent.chat(

--- a/server/agents/history_tutor/history_tutor.py
+++ b/server/agents/history_tutor/history_tutor.py
@@ -1,13 +1,14 @@
 import json
 import os
-from typing import List
+
+from ..agents import AgentResponse, ConversationalAgent
 from langchain_google_vertexai import ChatVertexAI, VertexAI
 from langchain.prompts import PromptTemplate
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
-from agents.agents import AgentResponse, ConversationalAgent
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+from typing import List
 
 
 # Adapted from Barista Bot: https://aistudio.google.com/app/prompts/barista-bot

--- a/server/agents/history_tutor/history_tutor_test.py
+++ b/server/agents/history_tutor/history_tutor_test.py
@@ -1,13 +1,14 @@
 import json
 import unittest
-from agents.history_tutor.history_tutor import (
+
+from ..agents import AgentState
+from .history_tutor import (
     HistoryTutor,
     load_file,
     BLACK_DEATH_TUTOR_CONTEXT,
 )
-from agents.agents import AgentState
+from ...utils.test_utils import evaluate, send_chat
 from langchain_google_vertexai import VertexAI
-from utils.test_utils import evaluate, send_chat
 from langchain.globals import set_debug
 
 

--- a/server/agents/physics_expert/physics_expert.py
+++ b/server/agents/physics_expert/physics_expert.py
@@ -1,7 +1,6 @@
-import time
-from langchain_google_vertexai import ChatVertexAI
-from agents.agents import AgentResponse, ConversationalAgent
 import os
+from ..agents import AgentResponse, ConversationalAgent
+from langchain_google_vertexai import ChatVertexAI
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 from langchain_core.prompts import PromptTemplate
 
@@ -75,7 +74,9 @@ class PhysicsExpert(ConversationalAgent):
             template=SYSTEM_PROMPT
         ).format(articles=article_content)
 
-        self.chat_model = ChatVertexAI(model="gemini-1.5-flash", examples=EXAMPLES, max_output_length=500)
+        self.chat_model = ChatVertexAI(
+            model="gemini-1.5-flash", examples=EXAMPLES, max_output_length=500
+        )
 
     def get_system_prompt(self) -> str:
         return self.system_context

--- a/server/agents/physics_expert/physics_expert_test.py
+++ b/server/agents/physics_expert/physics_expert_test.py
@@ -1,11 +1,8 @@
-import time
 import unittest
-from langchain.globals import set_debug
+from ..agents import AgentState, AgentResponse
+from .physics_expert import PhysicsExpert, load_resources
+from ...utils.test_utils import build_message_history_for_test
 from langchain_google_vertexai import VertexAI
-from agents.physics_expert.physics_expert import PhysicsExpert, load_resources
-import utils.test_utils
-from agents.agents import AgentState, AgentResponse
-from langchain.evaluation import load_evaluator, EvaluatorType
 from langsmith import unit, traceable
 
 
@@ -18,7 +15,7 @@ class PhysicsExpertTest(unittest.TestCase):
     @unit
     def test_chat(self):
         agent = PhysicsExpert()
-        message_history = utils.test_utils.build_message_history_for_test([])
+        message_history = build_message_history_for_test([])
         message = "Tell me about the double slit experiment."
         response, world_state = agent.chat(
             AgentState(

--- a/server/agents/registry.py
+++ b/server/agents/registry.py
@@ -5,6 +5,7 @@ from .fake_agent import FakeAgent
 from .history_tutor.history_tutor import HistoryTutor
 from .physics_expert.physics_expert import PhysicsExpert
 
+
 # Create conversational agents. An agent is a ConversationalAgent subclass.
 # It's able to respond to user messages based on the conversation history
 # and previous state.

--- a/server/main_test.py
+++ b/server/main_test.py
@@ -1,8 +1,8 @@
 import json
 import unittest
-from main import build_message_history
+
 from langchain_core.messages import HumanMessage, AIMessage
-from main import app
+from .main import app, build_message_history
 
 
 # Create a test class for the build_message_history function
@@ -39,15 +39,14 @@ class TestMain(unittest.TestCase):
 
         next_req = {
             "q": "user message 2",
-            "mode": "fake",
+            "agent_id": "fake",
             "world_state": json.dumps(world_state),
         }
 
         resp2 = self.client.post("/chat", data=next_req)
         data2 = json.loads(resp2.get_data())
         world_state2 = data2["world_state"]
-        self.assertEqual(world_state2["user_messages"][0], "user message 1")
-        self.assertEqual(world_state2["user_messages"][1], "user message 2")
+        self.assertEqual(world_state2["last_message"], "user message 2")
 
     @unittest.skip("Not implemented")
     def test_build_message_history(self):

--- a/server/utils/chat_client_test.py
+++ b/server/utils/chat_client_test.py
@@ -1,5 +1,6 @@
 import unittest
-from chat_client import ChatClient
+from .chat_client import ChatClient
+
 
 # TODO: Add real tests here.
 class ChatClientTest(unittest.TestCase):

--- a/server/utils/model_aligner_helper.py
+++ b/server/utils/model_aligner_helper.py
@@ -1,5 +1,6 @@
-from model_alignment import model_helper
 import vertexai
+
+from model_alignment import model_helper
 from vertexai.generative_models import GenerationConfig, GenerativeModel
 
 

--- a/server/utils/model_aligner_helper_test.py
+++ b/server/utils/model_aligner_helper_test.py
@@ -1,17 +1,17 @@
 import unittest
-import model_aligner_helper as helper
-from model_alignment import model_helper, single_run
+from model_alignment import single_run
+from .model_aligner_helper import VertexModelHelper
 
 
 # TODO: Add real tests here.
 class TestModelAlignerHelper(unittest.TestCase):
     def testVertexHelper(self):
-        vertex = helper.VertexModelHelper()
+        vertex = VertexModelHelper()
         result = vertex.predict("Tell me a joke", 0.5, candidate_count=1)
         print(result)
 
     def testGeneratesPrinciple(self):
-        single_run_prompt = single_run.AlignableSingleRun(helper.VertexModelHelper())
+        single_run_prompt = single_run.AlignableSingleRun(VertexModelHelper())
         initial_prompt = "Tell me a joke about {topic}."
         single_run_prompt.set_model_description(initial_prompt)
         output = single_run_prompt.send_input({"topic": "fish"})

--- a/server/utils/test_runner.py
+++ b/server/utils/test_runner.py
@@ -4,8 +4,8 @@ import time
 import click
 import unittest
 import concurrent.futures
-from dotenv import load_dotenv
 
+from dotenv import load_dotenv
 from rich import print
 from rich.panel import Panel
 
@@ -45,7 +45,15 @@ class TraceLogEntry:
     help="Maximum number of parallel threads to use when running the tests",
 )
 def run_tests(test_name, run_count, max_threads):
+    """Executes specified tests in parallel.
 
+    Args:
+        test_name (str): Name of the test (either a test suite or a specific test case within a suite).
+        run_count (int): Number of times to repeat each test.
+        max_threads (int): Maximum number of threads to use for parallel execution.
+    Returns:
+        None.
+    """
     if not test_name:
         click.secho(
             f"Warning: No test name provided, using default {DEFAULT_TEST_NAME}. There will be no LLM apis calls for this test.",

--- a/server/utils/test_utils.py
+++ b/server/utils/test_utils.py
@@ -1,11 +1,11 @@
-from typing import List
-
-from langchain_google_vertexai import VertexAI
-from agents.agents import AgentState
-from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
 import concurrent.futures
+
+from ..agents.agents import AgentState
+from langchain_google_vertexai import VertexAI
+from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
 from langchain.evaluation import load_evaluator, EvaluatorType
 from langchain_core.prompts import PromptTemplate
+from typing import List
 
 
 def build_message_history_for_test(message_history: List[str]) -> list[BaseMessage]:
@@ -27,8 +27,6 @@ def build_message_history_for_test(message_history: List[str]) -> list[BaseMessa
     rtn = []
     if not message_history:
         return rtn
-    if not len(message_history) % 2 == 0:
-        raise ValueError("Message history must have an even number of messages.")
 
     for i, message in enumerate(message_history):
         if i % 2 == 0:


### PR DESCRIPTION
- uses relative imports for local modules
- adds missing module initialization files
- verfied that tests/scripts run from both the repo root and server directory
  - run as module, i.e. `python3 -m server.utils.test_runner `, `python -m server.utils.chat_client`
- moves `chat_client` and `model_aligner_helper` to `util`
- adds docstrings
- minor fixes (unused imports, lint, failing tests)